### PR TITLE
Add OpenOCD configuration file

### DIFF
--- a/config/openocd/vaporlight.cfg
+++ b/config/openocd/vaporlight.cfg
@@ -1,0 +1,78 @@
+
+# script for stm32f1x family
+
+if { [info exists CHIPNAME] } {
+   set _CHIPNAME $CHIPNAME
+} else {
+   set _CHIPNAME stm32f1x
+}
+
+if { [info exists ENDIAN] } {
+   set _ENDIAN $ENDIAN
+} else {
+   set _ENDIAN little
+}
+
+# Work-area is a space in RAM used for flash programming
+# Use 1 kB for Vaporlight boards
+set WORKAREASIZE 0x400
+
+# JTAG speed should be <= F_CPU/6. F_CPU after reset is 8MHz, so use F_JTAG = 1MHz
+adapter_khz 1000
+
+adapter_nsrst_delay 100
+jtag_ntrst_delay 100
+
+#jtag scan chain
+if { [info exists CPUTAPID] } {
+   set _CPUTAPID $CPUTAPID
+} else {
+  # See STM Document RM0008
+  # Section 26.6.3
+   set _CPUTAPID 0x3ba00477
+}
+jtag newtap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_CPUTAPID
+
+if { [info exists BSTAPID] } {
+   # FIXME this never gets used to override defaults...
+   set _BSTAPID $BSTAPID
+} else {
+  # See STM Document RM0008
+  # Section 29.6.2
+  # Low density devices, Rev A
+  set _BSTAPID1 0x06412041
+  # Medium density devices, Rev A
+  set _BSTAPID2 0x06410041
+  # Medium density devices, Rev B and Rev Z
+  set _BSTAPID3 0x16410041
+  set _BSTAPID4 0x06420041
+  # High density devices, Rev A
+  set _BSTAPID5 0x06414041
+  # Connectivity line devices, Rev A and Rev Z
+  set _BSTAPID6 0x06418041
+  # XL line devices, Rev A
+  set _BSTAPID7 0x06430041
+  # VL line devices, Rev A and Z In medium-density and high-density value line devices
+  set _BSTAPID8 0x06420041
+  # VL line devices, Rev A
+  set _BSTAPID9 0x06428041
+
+}
+jtag newtap $_CHIPNAME bs -irlen 5 -expected-id $_BSTAPID1 \
+	-expected-id $_BSTAPID2 -expected-id $_BSTAPID3 \
+	-expected-id $_BSTAPID4 -expected-id $_BSTAPID5 \
+	-expected-id $_BSTAPID6 -expected-id $_BSTAPID7 \
+	-expected-id $_BSTAPID8 -expected-id $_BSTAPID9
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME cortex_m3 -endian $_ENDIAN -chain-position $_TARGETNAME
+
+$_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $_WORKAREASIZE -work-area-backup 0
+
+# flash size will be probed
+set _FLASHNAME $_CHIPNAME.flash
+flash bank $_FLASHNAME stm32f1x 0x08000000 0 0 0 $_TARGETNAME
+
+# if srst is not fitted use SYSRESETREQ to
+# perform a soft reset
+cortex_m3 reset_config sysresetreq


### PR DESCRIPTION
This adds a customized version of the OpenOCD stm32f1x target with a
lower WORKAREASIZE to account for the lower amount of available memory
on the Vaporlight boards.
