### PR TITLE
HACKING: fix network protocol spec

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -83,7 +83,7 @@ to 0xFFFF (highest or opaque)::
 For historicaly reasons, there is also a legacy
 low-precision version of the set-led command::
 
-  <set-led-8> ::= 0x01 <led-id:byte> <rgba>
+  <set-led-8> ::= 0x01 <led-id:int16> <rgba>
   <rgba-8> ::= <r:byte> <g:byte> <b:byte> <a:byte>
 
 Changes don't take effect until you issue

--- a/HACKING
+++ b/HACKING
@@ -83,7 +83,7 @@ to 0xFFFF (highest or opaque)::
 For historicaly reasons, there is also a legacy
 low-precision version of the set-led command::
 
-  <set-led-8> ::= 0x01 <led-id:int16> <rgba>
+  <set-led-8> ::= 0x01 <led-id:int16> <rgba-8>
   <rgba-8> ::= <r:byte> <g:byte> <b:byte> <a:byte>
 
 Changes don't take effect until you issue


### PR DESCRIPTION
the led-id is 16-bit even for the 8-bit set-color command (at least all implementations say so)